### PR TITLE
Updated UpperEll to use Checkstyle violations

### DIFF
--- a/config/import-control-test.xml
+++ b/config/import-control-test.xml
@@ -11,4 +11,5 @@
     <allow pkg="java.util"/>
     <allow pkg="java.nio"/>
     <allow pkg="java.lang"/>
+    <allow pkg="javax.xml.stream"/>
 </import-control>

--- a/src/main/java/org/checkstyle/autofix/parser/CheckstyleReportsParser.java
+++ b/src/main/java/org/checkstyle/autofix/parser/CheckstyleReportsParser.java
@@ -55,8 +55,7 @@ public final class CheckstyleReportsParser {
 
     }
 
-    public static List<CheckstyleViolation> parse(Path xmlPath)
-            throws IOException, XMLStreamException {
+    public static List<CheckstyleViolation> parse(Path xmlPath) {
 
         final List<CheckstyleViolation> result = new ArrayList<>();
 
@@ -89,6 +88,11 @@ public final class CheckstyleReportsParser {
                     reader.close();
                 }
             }
+
+        }
+        catch (IOException | XMLStreamException exception) {
+            throw new IllegalArgumentException("Failed to parse checkstyle XML report from: "
+                    + xmlPath, exception);
         }
 
         return result;

--- a/src/main/java/org/checkstyle/autofix/recipe/UpperEll.java
+++ b/src/main/java/org/checkstyle/autofix/recipe/UpperEll.java
@@ -17,9 +17,19 @@
 
 package org.checkstyle.autofix.recipe;
 
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.function.Function;
+
+import org.checkstyle.autofix.parser.CheckstyleViolation;
+import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.PrintOutputCapture;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.RecipeRunException;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
@@ -29,6 +39,16 @@ import org.openrewrite.java.tree.JavaType;
  * in long literals with uppercase 'L'.
  */
 public class UpperEll extends Recipe {
+
+    private final List<CheckstyleViolation> violations;
+
+    public UpperEll() {
+        this(new ArrayList<>());
+    }
+
+    public UpperEll(List<CheckstyleViolation> violations) {
+        this.violations = violations;
+    }
 
     @Override
     public String getDisplayName() {
@@ -46,20 +66,121 @@ public class UpperEll extends Recipe {
         return new UpperEllVisitor();
     }
 
-    /**
-     * Visitor that replaces lowercase 'l' suffixes in long literals with uppercase 'L'.
-     */
-    private static final class UpperEllVisitor extends JavaIsoVisitor<ExecutionContext> {
+    private final class UpperEllVisitor extends JavaIsoVisitor<ExecutionContext> {
+
+        private static final String LOWERCASE_L = "l";
+        private static final String UPPERCASE_L = "L";
+
+        private Path sourcePath;
+
+        @Override
+        public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+            this.sourcePath = cu.getSourcePath();
+            return super.visitCompilationUnit(cu, ctx);
+        }
+
         @Override
         public J.Literal visitLiteral(J.Literal literal, ExecutionContext ctx) {
             J.Literal result = super.visitLiteral(literal, ctx);
             final String valueSource = result.getValueSource();
 
-            if (valueSource != null && valueSource.endsWith("l")
-                    && result.getType() == JavaType.Primitive.Long) {
+            if (valueSource != null && valueSource.endsWith(LOWERCASE_L)
+                    && result.getType() == JavaType.Primitive.Long
+                    && isAtViolationLocation(result)) {
+
                 final String numericPart = valueSource.substring(0, valueSource.length() - 1);
-                final String newValueSource = numericPart + "L";
-                result = result.withValueSource(newValueSource);
+                result = result.withValueSource(numericPart + UPPERCASE_L);
+            }
+
+            return result;
+        }
+
+        private boolean isAtViolationLocation(J.Literal literal) {
+            final J.CompilationUnit cursor = getCursor().firstEnclosing(J.CompilationUnit.class);
+
+            final int line = computeLinePosition(cursor, literal, getCursor());
+            final int column = computeColumnPosition(cursor, literal, getCursor());
+
+            return violations.stream().anyMatch(violation -> {
+                return violation.getLine() == line
+                        && violation.getColumn() == column
+                        && Path.of(violation.getFileName()).equals(sourcePath);
+            });
+        }
+
+        /**
+         * Computes the position of a target element within a syntax tree using position calculator.
+         * This method traverses the given syntax tree and captures the printed output until the
+         * target element is encountered. When the target is found, a CancellationException
+         * is thrown to interrupt traversal, and the captured output is passed to the provided
+         * positionCalculator to compute the position.
+         *
+         * @param tree the root of the syntax tree to traverse
+         * @param targetElement the element whose position is to be computed
+         * @param cursor the current cursor in the tree traversal
+         * @param positionCalculator a function to compute the position from the printed output
+         * @return the computed position of the target element
+         * @throws IllegalStateException if the target element is not found in the tree
+         * @throws RecipeRunException if an error occurs during traversal
+         */
+        private int computePosition(
+                J tree,
+                J targetElement,
+                Cursor cursor,
+                Function<String, Integer> positionCalculator
+        ) {
+            final TreeVisitor<?, PrintOutputCapture<TreeVisitor<?, ?>>> printer =
+                    tree.printer(cursor);
+
+            final PrintOutputCapture<TreeVisitor<?, ?>> capture =
+                    new PrintOutputCapture<>(printer) {
+                        @Override
+                        public PrintOutputCapture<TreeVisitor<?, ?>> append(String text) {
+                            if (targetElement.isScope(getContext().getCursor().getValue())) {
+                                super.append(targetElement.getPrefix().getWhitespace());
+                                throw new CancellationException();
+                            }
+                            return super.append(text);
+                        }
+                    };
+
+            final int result;
+            try {
+                printer.visit(tree, capture, cursor.getParentOrThrow());
+                throw new IllegalStateException("Target element: " + targetElement
+                        + ", not found in the syntax tree.");
+            }
+            catch (CancellationException exception) {
+                result = positionCalculator.apply(capture.getOut());
+            }
+            catch (RecipeRunException exception) {
+                if (exception.getCause() instanceof CancellationException) {
+                    result = positionCalculator.apply(capture.getOut());
+                }
+                else {
+                    throw exception;
+                }
+            }
+            return result;
+        }
+
+        private int computeLinePosition(J tree, J targetElement, Cursor cursor) {
+            return computePosition(tree, targetElement, cursor,
+                    out -> 1 + Math.toIntExact(out.chars().filter(chr -> chr == '\n').count()));
+        }
+
+        private int computeColumnPosition(J tree, J targetElement, Cursor cursor) {
+            return computePosition(tree, targetElement, cursor, this::calculateColumnOffset);
+        }
+
+        private int calculateColumnOffset(String out) {
+            final int lineBreakIndex = out.lastIndexOf('\n');
+            final int result;
+            if (lineBreakIndex == -1) {
+                result = out.length();
+            }
+            else {
+                result = out.length() - lineBreakIndex - 1;
             }
             return result;
         }

--- a/src/test/java/org/checkstyle/autofix/recipe/AbstractRecipeTest.java
+++ b/src/test/java/org/checkstyle/autofix/recipe/AbstractRecipeTest.java
@@ -67,7 +67,8 @@ public abstract class AbstractRecipeTest implements RewriteTest {
      * @param testCaseName the name of the test case (should match directory and file names)
      * @throws IOException if files cannot be read
      */
-    protected void testRecipe(String recipePath, String testCaseName) throws IOException {
+    protected void testRecipe(String recipePath, String testCaseName)
+            throws IOException {
         final String testCaseDir = testCaseName.toLowerCase();
         final String inputFileName = "Input" + testCaseName + ".java";
         final String outputFileName = "Output" + testCaseName + ".java";

--- a/src/test/java/org/checkstyle/autofix/recipe/UpperEllTest.java
+++ b/src/test/java/org/checkstyle/autofix/recipe/UpperEllTest.java
@@ -18,7 +18,11 @@
 package org.checkstyle.autofix.recipe;
 
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
 
+import org.checkstyle.autofix.parser.CheckstyleReportsParser;
+import org.checkstyle.autofix.parser.CheckstyleViolation;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Recipe;
 
@@ -26,7 +30,12 @@ public class UpperEllTest extends AbstractRecipeTest {
 
     @Override
     protected Recipe getRecipe() {
-        return new UpperEll();
+        final String reportPath = "src/test/resources/org/checkstyle/autofix/recipe/upperell"
+                + "/report.xml";
+
+        final List<CheckstyleViolation> violations =
+                CheckstyleReportsParser.parse(Path.of(reportPath));
+        return new UpperEll(violations);
     }
 
     @Test

--- a/src/test/resources/org/checkstyle/autofix/recipe/upperell/complexlongliterals/InputComplexLongLiterals.java
+++ b/src/test/resources/org/checkstyle/autofix/recipe/upperell/complexlongliterals/InputComplexLongLiterals.java
@@ -11,8 +11,8 @@ public class InputComplexLongLiterals {
     private Long simpleLong = 1234l;
     private Long negativeLong = -5678l;
     private Long underscoreLong = 1_000_000l;
-    Long maxLongObject = 9223372036854775807l;
-    Long minLongObject = -9223372036854775808l;
+    Long maxLongObject = 9223372036854775807l;    //suppressed violation
+    Long minLongObject = -9223372036854775808l;    //suppressed violation
 
     public long calculate(long input1, long input2) {
         return input1 + input2 + 1000l;

--- a/src/test/resources/org/checkstyle/autofix/recipe/upperell/complexlongliterals/OutputComplexLongLiterals.java
+++ b/src/test/resources/org/checkstyle/autofix/recipe/upperell/complexlongliterals/OutputComplexLongLiterals.java
@@ -11,8 +11,8 @@ public class OutputComplexLongLiterals {
     private Long simpleLong = 1234L;
     private Long negativeLong = -5678L;
     private Long underscoreLong = 1_000_000L;
-    Long maxLongObject = 9223372036854775807L;
-    Long minLongObject = -9223372036854775808L;
+    Long maxLongObject = 9223372036854775807l;    //suppressed violation
+    Long minLongObject = -9223372036854775808l;    //suppressed violation
 
     public long calculate(long input1, long input2) {
         return input1 + input2 + 1000L;

--- a/src/test/resources/org/checkstyle/autofix/recipe/upperell/hexoctalliteral/InputHexOctalLiteral.java
+++ b/src/test/resources/org/checkstyle/autofix/recipe/upperell/hexoctalliteral/InputHexOctalLiteral.java
@@ -2,14 +2,14 @@ package org.checkstyle.autofix.recipe.upperell.hexoctalliteral;
 
 public class InputHexOctalLiteral {
     private long hexLower = 0x1ABCl;
-        private long hexUpper = 0X2DEFl;
-        private long octal = 0777l;
-        private long binary = 0b1010l;
-        private long decimal = 12345l;
+    private long hexUpper = 0X2DEFl;
+    private long octal = 0777l;
+    private long binary = 0b1010l;
+    private long decimal = 12345l;
 
     public void calculateValues() {
-        long hexResult = 0xDEADBEEFl;
-        long octalResult = 01234l;
+        long hexResult = 0xDEADBEEFl + 0xDEADBEFl; //suppressed violation for 0xDEADBEFl
+        long octalResult = 01234l + 0xDEADBEEFl;   //suppressed violation for 0xDEADBEFl
         long binaryResult = 0b11110000l;
     }
 }

--- a/src/test/resources/org/checkstyle/autofix/recipe/upperell/hexoctalliteral/OutputHexOctalLiteral.java
+++ b/src/test/resources/org/checkstyle/autofix/recipe/upperell/hexoctalliteral/OutputHexOctalLiteral.java
@@ -2,14 +2,14 @@ package org.checkstyle.autofix.recipe.upperell.hexoctalliteral;
 
 public class OutputHexOctalLiteral {
     private long hexLower = 0x1ABCL;
-        private long hexUpper = 0X2DEFL;
-        private long octal = 0777L;
-        private long binary = 0b1010L;
-        private long decimal = 12345L;
+    private long hexUpper = 0X2DEFL;
+    private long octal = 0777L;
+    private long binary = 0b1010L;
+    private long decimal = 12345L;
 
     public void calculateValues() {
-        long hexResult = 0xDEADBEEFL;
-        long octalResult = 01234L;
+        long hexResult = 0xDEADBEEFL + 0xDEADBEFl; //suppressed violation for 0xDEADBEFl
+        long octalResult = 01234L + 0xDEADBEEFl;   //suppressed violation for 0xDEADBEFl
         long binaryResult = 0b11110000L;
     }
 }

--- a/src/test/resources/org/checkstyle/autofix/recipe/upperell/report.xml
+++ b/src/test/resources/org/checkstyle/autofix/recipe/upperell/report.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="10.12.3">
+    <file name="org/checkstyle/autofix/recipe/upperell/stringandcomments/InputStringAndComments.java">
+        <error line="11" column="30" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="18" column="21" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+    </file>
+
+    <file name="org/checkstyle/autofix/recipe/upperell/hexoctalliteral/InputHexOctalLiteral.java">
+        <error line="4" column="28" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="5" column="28" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="6" column="25" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="7" column="26" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="8" column="27" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="11" column="25" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="12" column="27" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="13" column="28" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+    </file>
+
+    <file name="org/checkstyle/autofix/recipe/upperell/complexlongliterals/InputComplexLongLiterals.java">
+        <error line="4" column="35" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="5" column="39" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="7" column="27" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="8" column="27" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="11" column="30" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="12" column="32" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="13" column="34" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="18" column="33" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="22" column="57" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="23" column="32" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="23" column="36" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="23" column="40" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="27" column="39" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="27" column="45" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="27" column="51" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="32" column="17" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="33" column="30" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="34" column="26" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="36" column="45" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="37" column="41" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="38" column="33" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="43" column="19" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+        <error line="45" column="23" severity="error"
+               message="Use uppercase 'L' for long literals."
+               source="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+    </file>
+</checkstyle>


### PR DESCRIPTION
Fixes: https://github.com/checkstyle/checkstyle-openrewrite-recipes/issues/23
Updated UpperEll recipe to match source file and line number from the violation and fix it only when there is a match.