### PR TITLE
Updated CheckstyleAutoFix to load report

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -9,4 +9,5 @@
     <suppress checks="JavadocVariable" files=".*"/>
     <suppress checks="MissingJavadocMethod" files=".*"/>
     <suppress checks="DesignForExtension" files="[\\/]src[\\/]test[\\/]java[\\/]org[\\/]checkstyle[\\/]autofix[\\/]recipe[\\/]AbstractRecipeTest\.java"/>
+    <suppress checks="DesignForExtension" files="[\\/]src[\\/]main[\\/]java[\\/]org[\\/]checkstyle[\\/]autofix[\\/]CheckstyleAutoFix\.java"/>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -111,32 +111,6 @@
                 </configuration>
             </plugin>
 
-            <plugin>
-                <groupId>org.openrewrite.maven</groupId>
-                <artifactId>rewrite-maven-plugin</artifactId>
-                <version>${rewrite.maven.plugin}</version>
-                <configuration>
-                    <activeRecipes>
-                        <recipe>org.checkstyle.autofix.CheckstyleAutoFix</recipe>
-                    </activeRecipes>
-                    <exclusions>
-                        <exclusion>src/test/resources/**</exclusion>
-                    </exclusions>
-                    <recipeArtifactCoordinates>
-                        <coordinate>org.checkstyle.autofix:checkstyle-openrewrite-recipes:1.0.0</coordinate>
-                    </recipeArtifactCoordinates>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>checkstyle-autofix</id>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <!-- Checkstyle plugin for code style regulation -->
 
             <plugin>
@@ -176,6 +150,33 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <version>${rewrite.maven.plugin}</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>CheckstyleAutoFixConfigured</recipe>
+                    </activeRecipes>
+                    <exclusions>
+                        <exclusion>src/test/resources/**</exclusion>
+                    </exclusions>
+                    <recipeArtifactCoordinates>
+                        <coordinate>org.checkstyle.autofix:checkstyle-openrewrite-recipes:1.0.0</coordinate>
+                    </recipeArtifactCoordinates>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>checkstyle-autofix</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/src/main/java/org/checkstyle/autofix/CheckstyleAutoFix.java
+++ b/src/main/java/org/checkstyle/autofix/CheckstyleAutoFix.java
@@ -17,16 +17,23 @@
 
 package org.checkstyle.autofix;
 
-import java.util.Collections;
+import java.nio.file.Path;
 import java.util.List;
 
-import org.checkstyle.autofix.recipe.UpperEll;
+import org.checkstyle.autofix.parser.CheckstyleReportParser;
+import org.checkstyle.autofix.parser.CheckstyleViolation;
+import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 
 /**
  * Main recipe that automatically fixes all supported Checkstyle violations.
  */
 public class CheckstyleAutoFix extends Recipe {
+
+    @Option(displayName = "Violation report path",
+            description = "Path to the checkstyle violation report XML file.",
+            example = "target/checkstyle/checkstyle-report.xml")
+    private String violationReportPath;
 
     @Override
     public String getDisplayName() {
@@ -38,11 +45,16 @@ public class CheckstyleAutoFix extends Recipe {
         return "Automatically fixes Checkstyle violations.";
     }
 
+    public String getViolationReportPath() {
+        return violationReportPath;
+    }
+
     @Override
     public List<Recipe> getRecipeList() {
-        return Collections.singletonList(
 
-                new UpperEll()
-        );
+        final List<CheckstyleViolation> violations = CheckstyleReportParser
+                .parse(Path.of(getViolationReportPath()));
+
+        return CheckstyleRecipeRegistry.getRecipes(violations);
     }
 }

--- a/src/main/java/org/checkstyle/autofix/CheckstyleRecipeRegistry.java
+++ b/src/main/java/org/checkstyle/autofix/CheckstyleRecipeRegistry.java
@@ -1,0 +1,74 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle-openrewrite-recipes: Automatically fix Checkstyle violations with OpenRewrite.
+// Copyright (C) 2025 The Checkstyle OpenRewrite Recipes Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.autofix;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.checkstyle.autofix.parser.CheckstyleViolation;
+import org.checkstyle.autofix.recipe.UpperEll;
+import org.openrewrite.Recipe;
+
+public final class CheckstyleRecipeRegistry {
+
+    private static final Map<String, Function<List<CheckstyleViolation>, Recipe>> RECIPE_MAP =
+            new HashMap<>();
+
+    static {
+        RECIPE_MAP.put("UpperEllCheck", UpperEll::new);
+    }
+
+    private CheckstyleRecipeRegistry() {
+        // utility class
+    }
+
+    /**
+     * Returns a list of Recipe objects based on the given list of Checkstyle violations.
+     * The method groups violations by their check name, finds the matching recipe factory
+     * using the simple name of the check, and applies the factory to generate Recipe instances.
+     *
+     * @param violations the list of Checkstyle violations
+     * @return a list of generated Recipe objects
+     */
+    public static List<Recipe> getRecipes(List<CheckstyleViolation> violations) {
+
+        final Map<String, List<CheckstyleViolation>> violationsByCheck = violations.stream()
+                .collect(Collectors.groupingBy(CheckstyleViolation::getSource));
+
+        final List<Recipe> recipes = new ArrayList<>();
+
+        for (Map.Entry<String, List<CheckstyleViolation>> entry : violationsByCheck.entrySet()) {
+            final String checkName = entry.getKey();
+            final String simpleCheckName = checkName
+                    .substring(checkName.lastIndexOf('.') + 1);
+            final List<CheckstyleViolation> checkViolations = entry.getValue();
+
+            final Function<List<CheckstyleViolation>, Recipe> recipeFactory =
+                    RECIPE_MAP.get(simpleCheckName);
+            if (recipeFactory != null) {
+                recipes.add(recipeFactory.apply(checkViolations));
+            }
+        }
+
+        return recipes;
+    }
+}

--- a/src/main/java/org/checkstyle/autofix/parser/CheckstyleReportParser.java
+++ b/src/main/java/org/checkstyle/autofix/parser/CheckstyleReportParser.java
@@ -33,7 +33,7 @@ import javax.xml.stream.events.Attribute;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
-public final class CheckstyleReportsParser {
+public final class CheckstyleReportParser {
 
     private static final String FILE_TAG = "file";
 
@@ -51,7 +51,7 @@ public final class CheckstyleReportsParser {
 
     private static final String SOURCE_ATTR = "source";
 
-    private CheckstyleReportsParser() {
+    private CheckstyleReportParser() {
 
     }
 

--- a/src/main/java/org/checkstyle/autofix/recipe/UpperEll.java
+++ b/src/main/java/org/checkstyle/autofix/recipe/UpperEll.java
@@ -18,7 +18,6 @@
 package org.checkstyle.autofix.recipe;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.function.Function;
@@ -41,10 +40,6 @@ import org.openrewrite.java.tree.JavaType;
 public class UpperEll extends Recipe {
 
     private final List<CheckstyleViolation> violations;
-
-    public UpperEll() {
-        this(new ArrayList<>());
-    }
 
     public UpperEll(List<CheckstyleViolation> violations) {
         this.violations = violations;

--- a/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/src/main/resources/META-INF/rewrite/recipes.yml
@@ -1,10 +1,17 @@
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.checkstyle.autofix.CheckstyleAutoFix
-displayName: Checkstyle autoFix
-description: Automatically fixes Checkstyle violations.
+name: CheckstyleAutoFixConfigured
+displayName: Checkstyle Auto Fix Configured
+description: |
+  Automatically applies OpenRewrite recipes to fix Checkstyle violations
+  based on the provided Checkstyle XML violation report. This recipe serves
+  as an entry point to apply all auto-fixable rules configured in the report.
 tags:
   - checkstyle
+  - autofix
   - static-analysis
+  - java
+  - code-quality
 recipeList:
-  - org.checkstyle.autofix.recipe.UpperEll
+  - org.checkstyle.autofix.CheckstyleAutoFix:
+      violationReportPath: "target/checkstyle/checkstyle-report.xml"

--- a/src/test/java/org/checkstyle/autofix/CheckstyleRecipeRegistryTest.java
+++ b/src/test/java/org/checkstyle/autofix/CheckstyleRecipeRegistryTest.java
@@ -1,0 +1,53 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle-openrewrite-recipes: Automatically fix Checkstyle violations with OpenRewrite.
+// Copyright (C) 2025 The Checkstyle OpenRewrite Recipes Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.autofix;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.checkstyle.autofix.parser.CheckstyleViolation;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Recipe;
+
+public class CheckstyleRecipeRegistryTest {
+
+    @Test
+    void testGetRecipesReturnsCorrectRecipe() {
+
+        final List<CheckstyleViolation> violations = List.of(
+                new CheckstyleViolation(5, 10, "error",
+                        "com.puppycrawl.tools.checkstyle.checks.UpperEllCheck",
+                        "Use uppercase 'L' for long literals.", "Example1.java"),
+
+                new CheckstyleViolation(15, 20, "error",
+                        "com.puppycrawl.tools.checkstyle.checks.UpperEllCheck",
+                        "Use uppercase 'L' for long literals.", "Example2.java"),
+
+                new CheckstyleViolation(8, 12, "error",
+                        "com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck",
+                        "Variable should be declared final.", "Example3.java")
+        );
+
+        final List<Recipe> recipes = CheckstyleRecipeRegistry.getRecipes(violations);
+
+        assertEquals(1, recipes.size(), "Should return one recipe");
+        assertEquals("UpperEll recipe", recipes.get(0).getDisplayName());
+    }
+
+}

--- a/src/test/java/org/checkstyle/autofix/parser/CheckstyleReportsParserTest.java
+++ b/src/test/java/org/checkstyle/autofix/parser/CheckstyleReportsParserTest.java
@@ -36,7 +36,7 @@ public class CheckstyleReportsParserTest {
     @Test
     public void testParseFromResource() throws Exception {
         final Path xmlPath = Path.of(getPath("checkstyle-report.xml"));
-        final List<CheckstyleViolation> records = CheckstyleReportsParser.parse(xmlPath);
+        final List<CheckstyleViolation> records = CheckstyleReportParser.parse(xmlPath);
 
         assertNotNull(records);
         assertEquals(1, records.size());
@@ -53,7 +53,7 @@ public class CheckstyleReportsParserTest {
     @Test
     public void testParseMultipleFilesReport() throws Exception {
         final Path xmlPath = Path.of(getPath("checkstyle-multiple-files.xml"));
-        final List<CheckstyleViolation> records = CheckstyleReportsParser.parse(xmlPath);
+        final List<CheckstyleViolation> records = CheckstyleReportParser.parse(xmlPath);
 
         assertNotNull(records);
         assertEquals(3, records.size());

--- a/src/test/java/org/checkstyle/autofix/recipe/UpperEllTest.java
+++ b/src/test/java/org/checkstyle/autofix/recipe/UpperEllTest.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
-import org.checkstyle.autofix.parser.CheckstyleReportsParser;
+import org.checkstyle.autofix.parser.CheckstyleReportParser;
 import org.checkstyle.autofix.parser.CheckstyleViolation;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Recipe;
@@ -34,7 +34,7 @@ public class UpperEllTest extends AbstractRecipeTest {
                 + "/report.xml";
 
         final List<CheckstyleViolation> violations =
-                CheckstyleReportsParser.parse(Path.of(reportPath));
+                CheckstyleReportParser.parse(Path.of(reportPath));
         return new UpperEll(violations);
     }
 


### PR DESCRIPTION
Fixes: https://github.com/checkstyle/checkstyle-openrewrite-recipes/issues/22

Implemented logic to load the Checkstyle violation report, group violations by check, and initialize the UpperEllRecipe with violations related to the UpperEllCheck, if any are present.