### PR TITLE
Issue #106: enforce pitest

### DIFF
--- a/.ci/pitest-survival-check.groovy
+++ b/.ci/pitest-survival-check.groovy
@@ -1,0 +1,347 @@
+import groovy.io.FileType
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.Immutable
+import groovy.xml.XmlUtil
+
+int exitCode = checkPitestReport()
+System.exit(exitCode)
+
+/**
+ * Check the generated pitest report. Parse the surviving and suppressed mutations and compare
+ * them.
+ *
+ * @return {@code 0} if pitest report is as expected, {@code 1} otherwise
+ */
+private static int checkPitestReport() {
+    final XmlParser xmlParser = new XmlParser()
+    File mutationReportFile = null
+    final String suppressedMutationFileUri = ".${File.separator}config${File.separator}" +
+            "pitest-suppressions.xml"
+
+    final File pitReports =
+            new File(".${File.separator}target${File.separator}pit-reports")
+
+    if (!pitReports.exists()) {
+        throw new IllegalStateException(
+                "Pitest report directory does not exist, generate pitest report first")
+    }
+
+    pitReports.eachFileRecurse(FileType.FILES) {
+        if (it.name == 'mutations.xml') {
+            mutationReportFile = it
+        }
+    }
+    final Node mutationReportNode = xmlParser.parse(mutationReportFile)
+    final Set<Mutation> survivingMutations = getSurvivingMutations(mutationReportNode)
+
+    final File suppressionFile = new File(suppressedMutationFileUri)
+    Set<Mutation> suppressedMutations = new TreeSet<>()
+    if (suppressionFile.exists()) {
+        final Node suppressedMutationNode = xmlParser.parse(suppressedMutationFileUri)
+        suppressedMutations = getSuppressedMutations(suppressedMutationNode)
+    }
+
+    if (survivingMutations.isEmpty()) {
+        if (suppressionFile.exists()) {
+            suppressionFile.delete()
+        }
+    }
+    else {
+        final StringBuilder suppressionFileContent = new StringBuilder(1024)
+        suppressionFileContent.append(
+                '<?xml version="1.0" encoding="UTF-8"?>\n<suppressedMutations>\n')
+
+        survivingMutations.each {
+            suppressionFileContent.append(it.toXmlString())
+        }
+        suppressionFileContent.append('</suppressedMutations>\n')
+
+        if (!suppressionFile.exists()) {
+            suppressionFile.createNewFile()
+        }
+        suppressionFile.write(suppressionFileContent.toString())
+    }
+
+    return printComparisonToConsole(survivingMutations, suppressedMutations)
+}
+
+/**
+ * Get the surviving mutations. All child nodes of the main {@code mutations} node
+ * are parsed.
+ *
+ * @param mainNode the main {@code mutations} node
+ * @return A set of surviving mutations
+ */
+private static Set<Mutation> getSurvivingMutations(Node mainNode) {
+
+    final List<Node> children = mainNode.children()
+    final Set<Mutation> survivingMutations = new TreeSet<>()
+
+    children.each { node ->
+        final Node mutationNode = node as Node
+
+        final String mutationStatus = mutationNode.attribute("status")
+
+        if (mutationStatus == "SURVIVED" || mutationStatus == "NO_COVERAGE") {
+            survivingMutations.add(getMutation(mutationNode))
+        }
+    }
+    return survivingMutations
+}
+
+/**
+ * Get the suppressed mutations. All child nodes of the main {@code suppressedMutations} node
+ * are parsed.
+ *
+ * @param mainNode the main {@code suppressedMutations} node
+ * @return A set of suppressed mutations
+ */
+private static Set<Mutation> getSuppressedMutations(Node mainNode) {
+    final List<Node> children = mainNode.children()
+    final Set<Mutation> suppressedMutations = new TreeSet<>()
+
+    children.each { node ->
+        final Node mutationNode = node as Node
+        suppressedMutations.add(getMutation(mutationNode))
+    }
+    return suppressedMutations
+}
+
+/**
+ * Construct the {@link Mutation} object from the {@code mutation} XML node.
+ * The {@code mutations.xml} file is parsed to get the {@code mutationNode}.
+ *
+ * @param mutationNode the {@code mutation} XML node
+ * @return {@link Mutation} object represented by the {@code mutation} XML node
+ */
+private static Mutation getMutation(Node mutationNode) {
+    final List childNodes = mutationNode.children()
+
+    String sourceFile = null
+    String mutatedClass = null
+    String mutatedMethod = null
+    String mutator = null
+    String lineContent = null
+    String description = null
+    String mutationClassPackage = null
+    int lineNumber = 0
+    childNodes.each {
+        final Node childNode = it as Node
+        final String text = childNode.name()
+
+        final String childNodeText = XmlUtil.escapeXml(childNode.text())
+        switch (text) {
+            case "sourceFile":
+                sourceFile = childNodeText
+                break
+            case "mutatedClass":
+                mutatedClass = childNodeText
+                mutationClassPackage = mutatedClass.split("[A-Z]")[0]
+                break
+            case "mutatedMethod":
+                mutatedMethod = childNodeText
+                break
+            case "mutator":
+                mutator = childNodeText
+                break
+            case "description":
+                description = childNodeText
+                break
+            case "lineNumber":
+                lineNumber = Integer.parseInt(childNodeText)
+                break
+            case "lineContent":
+                lineContent = childNodeText
+                break
+        }
+    }
+    if (lineContent == null) {
+        final String mutationFileName = mutationClassPackage + sourceFile
+        final String startingPath =
+                ".${File.separator}src${File.separator}main${File.separator}java${File.separator}"
+        final String javaExtension = ".java"
+        final String mutationFilePath = startingPath + mutationFileName
+                .substring(0, mutationFileName.length() - javaExtension.length())
+                .replace(".", File.separator) + javaExtension
+
+        final File file = new File(mutationFilePath)
+        lineContent = XmlUtil.escapeXml(file.readLines().get(lineNumber - 1).trim())
+    }
+    if (lineNumber == 0) {
+        lineNumber = -1
+    }
+
+    final String unstableAttributeValue = mutationNode.attribute("unstable")
+    final boolean isUnstable = Boolean.parseBoolean(unstableAttributeValue)
+
+    return new Mutation(sourceFile, mutatedClass, mutatedMethod, mutator, description,
+            lineContent, lineNumber, isUnstable)
+}
+
+/**
+ * Compare surviving and suppressed mutations. The comparison passes successfully (i.e. returns 0)
+ * when:
+ * <ol>
+ *   <li>Surviving and suppressed mutations are equal.</li>
+ *   <li>There are extra suppressed mutations but they are unstable
+ *     i.e. {@code unstable="true"}.</li>
+ * </ol>
+ * The comparison fails (i.e. returns 1) when:
+ * <ol>
+ *     <li>Surviving mutations are not present in the suppressed list.</li>
+ *     <li>There are mutations in the suppression list that are not there is surviving list.</li>
+ * </ol>
+ *
+ * @param survivingMutations A set of surviving mutations
+ * @param suppressedMutations A set of suppressed mutations
+ * @return {@code 0} if comparison passes successfully
+ */
+private static int printComparisonToConsole(Set<Mutation> survivingMutations,
+                                            Set<Mutation> suppressedMutations) {
+    final Set<Mutation> survivingUnsuppressedMutations =
+            setDifference(survivingMutations, suppressedMutations)
+    final Set<Mutation> extraSuppressions =
+            setDifference(suppressedMutations, survivingMutations)
+
+    final int exitCode
+    if (survivingMutations == suppressedMutations) {
+        exitCode = 0
+        println 'No new surviving mutation(s) found.'
+    }
+    else if (survivingUnsuppressedMutations.isEmpty()
+            && hasOnlyUnstableMutations(extraSuppressions)) {
+        exitCode = 0
+        println 'No new surviving mutation(s) found.'
+    }
+    else {
+        if (!survivingUnsuppressedMutations.isEmpty()) {
+            println "New surviving mutation(s) found:"
+            survivingUnsuppressedMutations.each {
+                println it
+            }
+        }
+        if (!extraSuppressions.isEmpty()
+                && extraSuppressions.any { !it.isUnstable() }) {
+            println "\nUnnecessary suppressed mutation(s) found and should be removed:"
+            extraSuppressions.each {
+                if (!it.isUnstable()) {
+                    println it
+                }
+            }
+        }
+        exitCode = 1
+    }
+    return exitCode
+}
+
+/**
+ * Whether a set has only unstable mutations.
+ *
+ * @param mutations A set of mutations
+ * @return {@code true} if a set has only unstable mutations
+ */
+private static boolean hasOnlyUnstableMutations(Set<Mutation> mutations) {
+    return mutations.every { it.isUnstable() }
+}
+
+/**
+ * Determine the difference between 2 sets. The result is {@code setOne - setTwo}.
+ *
+ * @param setOne The first set in the difference
+ * @param setTwo The second set in the difference
+ * @return {@code setOne - setTwo}
+ */
+private static Set<Mutation> setDifference(final Set<Mutation> setOne,
+                                           final Set<Mutation> setTwo) {
+    final Set<Mutation> result = new TreeSet<>(setOne)
+    result.removeIf { mutation -> setTwo.contains(mutation) }
+    return result
+}
+
+/**
+ * A class to represent the XML {@code mutation} node.
+ */
+@EqualsAndHashCode(excludes = ["lineNumber", "unstable"])
+@Immutable
+class Mutation implements Comparable<Mutation> {
+
+    /**
+     * Mutation nodes present in suppressions file do not have a {@code lineNumber}.
+     * The {@code lineNumber} is set to {@code -1} for such mutations.
+     */
+    private static final int LINE_NUMBER_NOT_PRESENT_VALUE = -1
+
+    String sourceFile
+    String mutatedClass
+    String mutatedMethod
+    String mutator
+    String description
+    String lineContent
+    int lineNumber
+    boolean unstable
+
+    @Override
+    String toString() {
+        String toString = """
+            Source File: "${getSourceFile()}"
+            Class: "${getMutatedClass()}"
+            Method: "${getMutatedMethod()}"
+            Line Contents: "${getLineContent()}"
+            Mutator: "${getMutator()}"
+            Description: "${getDescription()}"
+            """.stripIndent()
+        if (getLineNumber() != LINE_NUMBER_NOT_PRESENT_VALUE) {
+            toString += 'Line Number: ' + getLineNumber()
+        }
+        return toString
+    }
+
+    @Override
+    int compareTo(Mutation other) {
+        int i = getSourceFile() <=> other.getSourceFile()
+        if (i != 0) {
+            return i
+        }
+
+        i = getMutatedClass() <=> other.getMutatedClass()
+        if (i != 0) {
+            return i
+        }
+
+        i = getMutatedMethod() <=> other.getMutatedMethod()
+        if (i != 0) {
+            return i
+        }
+
+        i = getLineContent() <=> other.getLineContent()
+        if (i != 0) {
+            return i
+        }
+
+        i = getMutator() <=> other.getMutator()
+        if (i != 0) {
+            return i
+        }
+
+        return getDescription() <=> other.getDescription()
+    }
+
+    /**
+     * XML format of the mutation.
+     *
+     * @return XML format of the mutation
+     */
+    String toXmlString() {
+        return """
+            <mutation unstable="${isUnstable()}">
+              <sourceFile>${getSourceFile()}</sourceFile>
+              <mutatedClass>${getMutatedClass()}</mutatedClass>
+              <mutatedMethod>${getMutatedMethod()}</mutatedMethod>
+              <mutator>${getMutator()}</mutator>
+              <description>${getDescription()}</description>
+              <lineContent>${getLineContent()}</lineContent>
+            </mutation>
+            """.stripIndent(10)
+    }
+
+}

--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Attention, there is no "-x" to avoid problems on CircleCI
+set -e
+
+echo "Generation of pitest report:"
+echo "./mvnw -e --no-transfer-progress -Ppitest clean test-compile org.pitest:pitest-maven:mutationCoverage"
+set +e
+./mvnw -e --no-transfer-progress -Ppitest clean test-compile org.pitest:pitest-maven:mutationCoverage
+EXIT_CODE=$?
+set -e
+echo "Execution of comparison of suppressed mutations survivals and current survivals:"
+echo "groovy .ci/pitest-survival-check.groovy"
+groovy .ci/pitest-survival-check.groovy
+exit $EXIT_CODE

--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -1,0 +1,43 @@
+name: Pitest
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  pitest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+
+      - name: Install Groovy
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y groovy
+
+      - name: Setup Maven cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+
+      - name: Run Pitest with suppression check
+        run: ./.ci/pitest.sh
+
+      - name: Upload Pitest Report on Failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pitest-report
+          path: target/pit-reports/
+          retention-days: 7

--- a/config/pitest-suppressions.xml
+++ b/config/pitest-suppressions.xml
@@ -1,0 +1,1155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressedMutations>
+
+  <mutation unstable="false">
+    <sourceFile>CheckConfiguration.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.CheckConfiguration</mutatedClass>
+    <mutatedMethod>getProperty</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>if (properties.containsKey(key)) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CheckConfiguration.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.CheckConfiguration</mutatedClass>
+    <mutatedMethod>getProperty</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::get</description>
+    <lineContent>result = globalProperties.get(key);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CheckConfiguration.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.CheckConfiguration</mutatedClass>
+    <mutatedMethod>getPropertyOrDefault</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to org/checkstyle/autofix/parser/CheckConfiguration::getProperty</description>
+    <lineContent>String result = getProperty(key);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CheckConfiguration.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.CheckConfiguration</mutatedClass>
+    <mutatedMethod>getPropertyOrDefault</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>if (result == null) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CheckConfiguration.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.CheckConfiguration</mutatedClass>
+    <mutatedMethod>hasProperty</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::containsKey</description>
+    <lineContent>return properties.containsKey(key) || globalProperties.containsKey(key);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CheckConfiguration.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.CheckConfiguration</mutatedClass>
+    <mutatedMethod>hasProperty</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
+    <description>removed conditional - replaced equality check with false</description>
+    <lineContent>return properties.containsKey(key) || globalProperties.containsKey(key);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CheckConfiguration.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.CheckConfiguration</mutatedClass>
+    <mutatedMethod>hasProperty</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>return properties.containsKey(key) || globalProperties.containsKey(key);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CheckConfiguration.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.CheckConfiguration</mutatedClass>
+    <mutatedMethod>setGlobalProperty</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>globalProperties.put(key, value);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CheckConfiguration.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.CheckConfiguration</mutatedClass>
+    <mutatedMethod>setGlobalProperty</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>globalProperties.put(key, value);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CheckstyleAutoFix.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.CheckstyleAutoFix</mutatedClass>
+    <mutatedMethod>createReportParser</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator</mutator>
+    <description>negated conditional</description>
+    <lineContent>else if (path.endsWith(&quot;.sarif&quot;) || path.endsWith(&quot;.sarif.json&quot;)) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CheckstyleAutoFix.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.CheckstyleAutoFix</mutatedClass>
+    <mutatedMethod>createReportParser</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::endsWith</description>
+    <lineContent>else if (path.endsWith(&quot;.sarif&quot;) || path.endsWith(&quot;.sarif.json&quot;)) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CheckstyleAutoFix.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.CheckstyleAutoFix</mutatedClass>
+    <mutatedMethod>createReportParser</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
+    <description>removed conditional - replaced equality check with false</description>
+    <lineContent>else if (path.endsWith(&quot;.sarif&quot;) || path.endsWith(&quot;.sarif.json&quot;)) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CheckstyleAutoFix.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.CheckstyleAutoFix</mutatedClass>
+    <mutatedMethod>createReportParser</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>else if (path.endsWith(&quot;.sarif&quot;) || path.endsWith(&quot;.sarif.json&quot;)) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CheckstyleAutoFix.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.CheckstyleAutoFix</mutatedClass>
+    <mutatedMethod>getDescription</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator</mutator>
+    <description>replaced return value with &quot;&quot; for org/checkstyle/autofix/CheckstyleAutoFix::getDescription</description>
+    <lineContent>return &quot;Automatically fixes Checkstyle violations.&quot;;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CheckstyleAutoFix.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.CheckstyleAutoFix</mutatedClass>
+    <mutatedMethod>getDisplayName</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator</mutator>
+    <description>replaced return value with &quot;&quot; for org/checkstyle/autofix/CheckstyleAutoFix::getDisplayName</description>
+    <lineContent>return &quot;Checkstyle autoFix&quot;;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CheckstyleAutoFix.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.CheckstyleAutoFix</mutatedClass>
+    <mutatedMethod>loadCheckstyleConfiguration</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to org/checkstyle/autofix/CheckstyleAutoFix::getPropertiesPath</description>
+    <lineContent>return ConfigurationLoader.loadConfiguration(getConfigurationPath(), getPropertiesPath());</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CheckstyleRecipeRegistry.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.CheckstyleRecipeRegistry</mutatedClass>
+    <mutatedMethod>createRecipe</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>if (checkConfig != null) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CheckstyleRecipeRegistry.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.CheckstyleRecipeRegistry</mutatedClass>
+    <mutatedMethod>getRecipes</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/util/stream/Stream::filter with receiver</description>
+    <lineContent>.filter(Objects::nonNull)</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.ConfigurationLoader</mutatedClass>
+    <mutatedMethod>lambda$mapConfiguration$1</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::forEach</description>
+    <lineContent>inherited.forEach(childConfig::setGlobalProperty);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.ConfigurationLoader</mutatedClass>
+    <mutatedMethod>loadConfiguration</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>if (propFile == null) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.ConfigurationLoader</mutatedClass>
+    <mutatedMethod>loadConfiguration</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Properties::load</description>
+    <lineContent>props.load(input);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable</mutatedClass>
+    <mutatedMethod>getDescription</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator</mutator>
+    <description>replaced return value with &quot;&quot; for org/checkstyle/autofix/recipe/FinalLocalVariable::getDescription</description>
+    <lineContent>return &quot;Adds &apos;final&apos; modifier to local variables that never have their values changed.&quot;;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable</mutatedClass>
+    <mutatedMethod>getDisplayName</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator</mutator>
+    <description>replaced return value with &quot;&quot; for org/checkstyle/autofix/recipe/FinalLocalVariable::getDisplayName</description>
+    <lineContent>return &quot;FinalLocalVariable recipe&quot;;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$FinalLocalVariableMarker</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable id</description>
+    <lineContent>this.id = uuid;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$FinalLocalVariableMarker</mutatedClass>
+    <mutatedMethod>getId</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.NullReturnValsMutator</mutator>
+    <description>replaced return value with null for org/checkstyle/autofix/recipe/FinalLocalVariable$FinalLocalVariableMarker::getId</description>
+    <lineContent>return id;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$FinalLocalVariableMarker</mutatedClass>
+    <mutatedMethod>withId</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.NullReturnValsMutator</mutator>
+    <description>replaced return value with null for org/checkstyle/autofix/recipe/FinalLocalVariable$FinalLocalVariableMarker::withId</description>
+    <lineContent>return (M) new FinalLocalVariableMarker(uuid);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$LocalVariableVisitor</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable this$0</description>
+    <lineContent>private final class LocalVariableVisitor extends JavaIsoVisitor&lt;ExecutionContext&gt; {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$LocalVariableVisitor</mutatedClass>
+    <mutatedMethod>addFinalModifier</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to org/openrewrite/Tree::randomId</description>
+    <lineContent>modifiers.add(new J.Modifier(Tree.randomId(), finalPrefix,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$LocalVariableVisitor</mutatedClass>
+    <mutatedMethod>addFinalModifier</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/List::addAll</description>
+    <lineContent>modifiers.addAll(varDecl.getModifiers());</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$LocalVariableVisitor</mutatedClass>
+    <mutatedMethod>handleMultiVariableDeclaration</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/List::isEmpty</description>
+    <lineContent>if (violationsList.isEmpty()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$LocalVariableVisitor</mutatedClass>
+    <mutatedMethod>handleMultiVariableDeclaration</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
+    <description>removed conditional - replaced equality check with false</description>
+    <lineContent>if (violationsList.isEmpty()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$LocalVariableVisitor</mutatedClass>
+    <mutatedMethod>handleMultiVariableDeclaration</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to org/openrewrite/java/tree/J$VariableDeclarations$NamedVariable::withPrefix with receiver</description>
+    <lineContent>nonViolations.add(variable.withPrefix(Space.SINGLE_SPACE));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$LocalVariableVisitor</mutatedClass>
+    <mutatedMethod>isVariableDeclaration</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to org/openrewrite/Cursor::getParentTreeCursor with receiver</description>
+    <lineContent>&amp;&amp; !(getCursor().getParentTreeCursor()</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$LocalVariableVisitor</mutatedClass>
+    <mutatedMethod>isVariableDeclaration</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>&amp;&amp; varDecl.getTypeExpression() != null</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$LocalVariableVisitor</mutatedClass>
+    <mutatedMethod>isVariableDeclaration</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_ORDER_IF</mutator>
+    <description>removed conditional - replaced comparison check with true</description>
+    <lineContent>&amp;&amp; varDecl.getVariables().size() &gt; 1</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$LocalVariableVisitor</mutatedClass>
+    <mutatedMethod>isVariableDeclaration</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to org/openrewrite/Cursor::getValue</description>
+    <lineContent>.getValue() instanceof J.ClassDeclaration);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$LocalVariableVisitor</mutatedClass>
+    <mutatedMethod>isVariableDeclaration</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>.getValue() instanceof J.ClassDeclaration);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$LocalVariableVisitor</mutatedClass>
+    <mutatedMethod>visitVariableDeclarations</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>&amp;&amp; declarations.getTypeExpression() != null</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$LocalVariableVisitor</mutatedClass>
+    <mutatedMethod>visitVariableDeclarations</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to org/openrewrite/Cursor::getValue</description>
+    <lineContent>if (!(getCursor().getParentTreeCursor().getValue() instanceof J.ClassDeclaration)</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$LocalVariableVisitor</mutatedClass>
+    <mutatedMethod>visitVariableDeclarations</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>if (!(getCursor().getParentTreeCursor().getValue() instanceof J.ClassDeclaration)</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$LocalVariableVisitor</mutatedClass>
+    <mutatedMethod>visitVariableDeclarations</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to org/openrewrite/Cursor::getParentTreeCursor with receiver</description>
+    <lineContent>if (!(getCursor().getParentTreeCursor().getValue() instanceof J.ClassDeclaration)</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$MarkViolationVisitor</mutatedClass>
+    <mutatedMethod>lambda$isAtViolationLocation$0</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>&amp;&amp; absolutePath.endsWith(sourcePath)</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$MarkViolationVisitor</mutatedClass>
+    <mutatedMethod>lambda$isAtViolationLocation$0</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/nio/file/Path::toAbsolutePath with receiver</description>
+    <lineContent>final Path absolutePath = violation.getFilePath().toAbsolutePath();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$MarkViolationVisitor</mutatedClass>
+    <mutatedMethod>visitCompilationUnit</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/nio/file/Path::toAbsolutePath with receiver</description>
+    <lineContent>this.sourcePath = cu.getSourcePath().toAbsolutePath();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$MarkViolationVisitor</mutatedClass>
+    <mutatedMethod>visitVariableDeclarations</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to org/openrewrite/Cursor::getValue</description>
+    <lineContent>if (!(getCursor().getParentTreeCursor().getValue() instanceof J.ClassDeclaration)</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$MarkViolationVisitor</mutatedClass>
+    <mutatedMethod>visitVariableDeclarations</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>if (!(getCursor().getParentTreeCursor().getValue() instanceof J.ClassDeclaration)</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$MarkViolationVisitor</mutatedClass>
+    <mutatedMethod>visitVariableDeclarations</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to org/openrewrite/Cursor::getParentTreeCursor with receiver</description>
+    <lineContent>if (!(getCursor().getParentTreeCursor().getValue() instanceof J.ClassDeclaration)</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FinalLocalVariable.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.FinalLocalVariable$MarkViolationVisitor</mutatedClass>
+    <mutatedMethod>visitVariableDeclarations</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/UUID::randomUUID</description>
+    <lineContent>new FinalLocalVariableMarker(UUID.randomUUID()))));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Header.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.Header</mutatedClass>
+    <mutatedMethod>extractLicenseHeader</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to org/checkstyle/autofix/parser/CheckConfiguration::getPropertyOrDefault with argument</description>
+    <lineContent>.getPropertyOrDefault(CHARSET_PROPERTY, Charset.defaultCharset().name()));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Header.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.Header</mutatedClass>
+    <mutatedMethod>extractLicenseHeader</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to org/checkstyle/autofix/parser/CheckConfiguration::getProperty</description>
+    <lineContent>header = config.getProperty(HEADER_PROPERTY);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Header.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.Header</mutatedClass>
+    <mutatedMethod>extractLicenseHeader</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to org/checkstyle/autofix/parser/CheckConfiguration::getProperty with argument</description>
+    <lineContent>header = config.getProperty(HEADER_PROPERTY);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Header.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.Header</mutatedClass>
+    <mutatedMethod>extractLicenseHeader</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to org/checkstyle/autofix/recipe/Header::toLfLineEnding with argument</description>
+    <lineContent>header = toLfLineEnding(Files.readString(Path.of(headerFilePath), charsetToUse));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Header.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.Header</mutatedClass>
+    <mutatedMethod>extractLicenseHeader</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to org/checkstyle/autofix/parser/CheckConfiguration::hasProperty</description>
+    <lineContent>if (config.hasProperty(HEADER_PROPERTY)) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Header.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.Header</mutatedClass>
+    <mutatedMethod>extractLicenseHeader</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
+    <description>removed conditional - replaced equality check with false</description>
+    <lineContent>if (config.hasProperty(HEADER_PROPERTY)) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Header.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.Header</mutatedClass>
+    <mutatedMethod>getDescription</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator</mutator>
+    <description>replaced return value with &quot;&quot; for org/checkstyle/autofix/recipe/Header::getDescription</description>
+    <lineContent>return &quot;Adds headers to Java source files when missing.&quot;;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Header.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.Header</mutatedClass>
+    <mutatedMethod>getDisplayName</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator</mutator>
+    <description>replaced return value with &quot;&quot; for org/checkstyle/autofix/recipe/Header::getDisplayName</description>
+    <lineContent>return &quot;Header recipe&quot;;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Header.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.Header</mutatedClass>
+    <mutatedMethod>toLfLineEnding</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::replaceAll with receiver</description>
+    <lineContent>return text.replaceAll(&quot;(?x)\\\\r(?=\\\\n)|\\r(?=\\n)&quot;, &quot;&quot;);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Header.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.Header$HeaderVisitor</mutatedClass>
+    <mutatedMethod>hasViolation</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.BooleanTrueReturnValsMutator</mutator>
+    <description>replaced boolean return with true for org/checkstyle/autofix/recipe/Header$HeaderVisitor::hasViolation</description>
+    <lineContent>return violations.removeIf(violation -&gt; {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Header.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.Header$HeaderVisitor</mutatedClass>
+    <mutatedMethod>lambda$extractCurrentHeader$0</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to org/checkstyle/autofix/recipe/Header::toLfLineEnding with argument</description>
+    <lineContent>+ toLfLineEnding(comment.getSuffix());</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Header.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.Header$HeaderVisitor</mutatedClass>
+    <mutatedMethod>lambda$extractCurrentHeader$0</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to org/checkstyle/autofix/recipe/Header$HeaderVisitor::getCursor</description>
+    <lineContent>return comment.printComment(getCursor())</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Header.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.Header$HeaderVisitor</mutatedClass>
+    <mutatedMethod>lambda$hasViolation$1</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.BooleanTrueReturnValsMutator</mutator>
+    <description>replaced boolean return with true for org/checkstyle/autofix/recipe/Header$HeaderVisitor::lambda$hasViolation$1</description>
+    <lineContent>return violation.getFilePath().endsWith(filePath);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Header.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.Header$HeaderVisitor</mutatedClass>
+    <mutatedMethod>visit</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to org/openrewrite/java/JavaIsoVisitor::visit with argument</description>
+    <lineContent>J result = super.visit(tree, executionContext);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Header.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.Header$HeaderVisitor</mutatedClass>
+    <mutatedMethod>visit</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/nio/file/Path::toAbsolutePath with receiver</description>
+    <lineContent>final Path filePath = sourceFile.getSourcePath().toAbsolutePath();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Header.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.Header$HeaderVisitor</mutatedClass>
+    <mutatedMethod>visit</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>if (hasViolation(filePath) &amp;&amp; !currentHeader.startsWith(licenseHeader)) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Header.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.Header$HeaderVisitor</mutatedClass>
+    <mutatedMethod>visit</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to org/openrewrite/java/JavaIsoVisitor::visit with argument</description>
+    <lineContent>result = super.visit(sourceFile, executionContext);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>HexLiteralCase.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.HexLiteralCase</mutatedClass>
+    <mutatedMethod>getDescription</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator</mutator>
+    <description>replaced return value with &quot;&quot; for org/checkstyle/autofix/recipe/HexLiteralCase::getDescription</description>
+    <lineContent>return &quot;Replace HexLiteral lowercase (a-f) with UpperCase (A-F) &quot;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>HexLiteralCase.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.HexLiteralCase</mutatedClass>
+    <mutatedMethod>getDisplayName</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator</mutator>
+    <description>replaced return value with &quot;&quot; for org/checkstyle/autofix/recipe/HexLiteralCase::getDisplayName</description>
+    <lineContent>return &quot;HexLiteralCase Recipe&quot;;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>HexLiteralCase.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.HexLiteralCase$HexLiteralCaseVisitor</mutatedClass>
+    <mutatedMethod>isAtViolationLocation</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.BooleanTrueReturnValsMutator</mutator>
+    <description>replaced boolean return with true for org/checkstyle/autofix/recipe/HexLiteralCase$HexLiteralCaseVisitor::isAtViolationLocation</description>
+    <lineContent>return violations.stream().anyMatch(violation -&gt; {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>HexLiteralCase.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.HexLiteralCase$HexLiteralCaseVisitor</mutatedClass>
+    <mutatedMethod>lambda$isAtViolationLocation$0</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>&amp;&amp; absolutePath.endsWith(sourcePath);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>HexLiteralCase.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.HexLiteralCase$HexLiteralCaseVisitor</mutatedClass>
+    <mutatedMethod>lambda$isAtViolationLocation$0</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>&amp;&amp; violation.getColumn() == column</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>HexLiteralCase.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.HexLiteralCase$HexLiteralCaseVisitor</mutatedClass>
+    <mutatedMethod>lambda$isAtViolationLocation$0</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/nio/file/Path::toAbsolutePath with receiver</description>
+    <lineContent>final Path absolutePath = violation.getFilePath().toAbsolutePath();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>HexLiteralCase.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.HexLiteralCase$HexLiteralCaseVisitor</mutatedClass>
+    <mutatedMethod>lambda$isAtViolationLocation$0</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>return violation.getLine() == line</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>HexLiteralCase.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.HexLiteralCase$HexLiteralCaseVisitor</mutatedClass>
+    <mutatedMethod>lambda$isAtViolationLocation$0</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.BooleanTrueReturnValsMutator</mutator>
+    <description>replaced boolean return with true for org/checkstyle/autofix/recipe/HexLiteralCase$HexLiteralCaseVisitor::lambda$isAtViolationLocation$0</description>
+    <lineContent>return violation.getLine() == line</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>HexLiteralCase.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.HexLiteralCase$HexLiteralCaseVisitor</mutatedClass>
+    <mutatedMethod>shouldProcessLiteral</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
+    <description>removed conditional - replaced equality check with false</description>
+    <lineContent>&amp;&amp; (literal.getType() == JavaType.Primitive.Long</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>HexLiteralCase.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.HexLiteralCase$HexLiteralCaseVisitor</mutatedClass>
+    <mutatedMethod>shouldProcessLiteral</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
+    <description>removed conditional - replaced equality check with false</description>
+    <lineContent>&amp;&amp; (valueSource.startsWith(HEX_PREFIX)</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>HexLiteralCase.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.HexLiteralCase$HexLiteralCaseVisitor</mutatedClass>
+    <mutatedMethod>shouldProcessLiteral</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>&amp;&amp; isAtViolationLocation(literal);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>HexLiteralCase.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.HexLiteralCase$HexLiteralCaseVisitor</mutatedClass>
+    <mutatedMethod>shouldProcessLiteral</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>return valueSource != null</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>HexLiteralCase.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.HexLiteralCase$HexLiteralCaseVisitor</mutatedClass>
+    <mutatedMethod>shouldProcessLiteral</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>|| literal.getType() == JavaType.Primitive.Int)</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>HexLiteralCase.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.HexLiteralCase$HexLiteralCaseVisitor</mutatedClass>
+    <mutatedMethod>shouldProcessLiteral</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>|| valueSource.startsWith(HEX_PREFIX.toUpperCase(Locale.ROOT)))</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>HexLiteralCase.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.HexLiteralCase$HexLiteralCaseVisitor</mutatedClass>
+    <mutatedMethod>visitCompilationUnit</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/nio/file/Path::toAbsolutePath with receiver</description>
+    <lineContent>this.sourcePath = cu.getSourcePath().toAbsolutePath();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>HexLiteralCase.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.HexLiteralCase$HexLiteralCaseVisitor</mutatedClass>
+    <mutatedMethod>visitLiteral</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to org/openrewrite/java/JavaIsoVisitor::visitLiteral with argument</description>
+    <lineContent>J.Literal result = super.visitLiteral(literal, executionContext);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PositionHelper.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.PositionHelper</mutatedClass>
+    <mutatedMethod>calculateColumnOffset</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
+    <description>removed conditional - replaced equality check with false</description>
+    <lineContent>if (lineBreakIndex == -1) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PositionHelper.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.PositionHelper</mutatedClass>
+    <mutatedMethod>calculateColumnOffset</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::length</description>
+    <lineContent>result = out.length();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PositionHelper.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.PositionHelper</mutatedClass>
+    <mutatedMethod>computePosition</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>if (exception.getCause() instanceof CancellationException) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PositionHelper.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.PositionHelper</mutatedClass>
+    <mutatedMethod>computePosition</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to org/openrewrite/Cursor::getParentOrThrow with receiver</description>
+    <lineContent>printer.visit(tree, capture, cursor.getParentOrThrow());</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PositionHelper.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.PositionHelper</mutatedClass>
+    <mutatedMethod>computePosition</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/Integer::intValue</description>
+    <lineContent>result = positionCalculator.apply(capture.getOut());</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PositionHelper.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.PositionHelper</mutatedClass>
+    <mutatedMethod>computePosition</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/function/Function::apply</description>
+    <lineContent>result = positionCalculator.apply(capture.getOut());</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PositionHelper.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.PositionHelper</mutatedClass>
+    <mutatedMethod>computePosition</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to org/openrewrite/PrintOutputCapture::getOut</description>
+    <lineContent>result = positionCalculator.apply(capture.getOut());</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PositionHelper.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.PositionHelper</mutatedClass>
+    <mutatedMethod>computePosition</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/function/Function::apply with argument</description>
+    <lineContent>result = positionCalculator.apply(capture.getOut());</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PositionHelper.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.PositionHelper</mutatedClass>
+    <mutatedMethod>computePosition</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::valueOf</description>
+    <lineContent>throw new IllegalStateException(&quot;Target element: &quot; + targetElement</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PositionHelper.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.PositionHelper</mutatedClass>
+    <mutatedMethod>lambda$computeColumnPosition$2</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>&amp;&amp; literal.getValue() instanceof Number</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PositionHelper.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.PositionHelper</mutatedClass>
+    <mutatedMethod>lambda$computeColumnPosition$2</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>&amp;&amp; literal.getValueSource() != null</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PositionHelper.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.PositionHelper$1</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable val$cursor</description>
+    <lineContent>new PrintOutputCapture&lt;&gt;(printer) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PositionHelper.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.PositionHelper$1</mutatedClass>
+    <mutatedMethod>append</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.NullReturnValsMutator</mutator>
+    <description>replaced return value with null for org/checkstyle/autofix/PositionHelper$1::append</description>
+    <lineContent>return super.append(text);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PositionHelper.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.PositionHelper$1</mutatedClass>
+    <mutatedMethod>append</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to org/openrewrite/java/tree/Comment::printComment</description>
+    <lineContent>super.append(comment.printComment(cursor) + comment.getSuffix());</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RedundantImport.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.RedundantImport</mutatedClass>
+    <mutatedMethod>getDescription</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator</mutator>
+    <description>replaced return value with &quot;&quot; for org/checkstyle/autofix/recipe/RedundantImport::getDescription</description>
+    <lineContent>return &quot;Remove duplicate imports, java.lang imports, and same package imports&quot;;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RedundantImport.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.RedundantImport</mutatedClass>
+    <mutatedMethod>getDisplayName</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator</mutator>
+    <description>replaced return value with &quot;&quot; for org/checkstyle/autofix/recipe/RedundantImport::getDisplayName</description>
+    <lineContent>return &quot;Remove redundant imports&quot;;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RedundantImport.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.RedundantImport$RemoveRedundantImportsVisitor</mutatedClass>
+    <mutatedMethod>getCurrentPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>if (compilationUnit.getPackageDeclaration() != null) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RedundantImport.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.RedundantImport$RemoveRedundantImportsVisitor</mutatedClass>
+    <mutatedMethod>isAtViolationLocation</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.BooleanTrueReturnValsMutator</mutator>
+    <description>replaced boolean return with true for org/checkstyle/autofix/recipe/RedundantImport$RemoveRedundantImportsVisitor::isAtViolationLocation</description>
+    <lineContent>return violations.removeIf(violation -&gt; {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RedundantImport.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.RedundantImport$RemoveRedundantImportsVisitor</mutatedClass>
+    <mutatedMethod>isRedundant</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to org/openrewrite/java/tree/J$Import::isStatic</description>
+    <lineContent>else if (currentPackage != null &amp;&amp; !importStmt.isStatic()</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RedundantImport.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.RedundantImport$RemoveRedundantImportsVisitor</mutatedClass>
+    <mutatedMethod>isRedundant</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>else if (currentPackage != null &amp;&amp; !importStmt.isStatic()</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RedundantImport.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.RedundantImport$RemoveRedundantImportsVisitor</mutatedClass>
+    <mutatedMethod>isRedundant</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to org/openrewrite/java/tree/J$Import::isStatic</description>
+    <lineContent>if (!importStmt.isStatic() &amp;&amp; importName.startsWith(JAVA_LANG_PREFIX)) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RedundantImport.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.RedundantImport$RemoveRedundantImportsVisitor</mutatedClass>
+    <mutatedMethod>isRedundant</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>if (!importStmt.isStatic() &amp;&amp; importName.startsWith(JAVA_LANG_PREFIX)) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RedundantImport.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.RedundantImport$RemoveRedundantImportsVisitor</mutatedClass>
+    <mutatedMethod>lambda$isAtViolationLocation$1</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>&amp;&amp; absolutePath.endsWith(sourcePath);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RedundantImport.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.RedundantImport$RemoveRedundantImportsVisitor</mutatedClass>
+    <mutatedMethod>lambda$isAtViolationLocation$1</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>&amp;&amp; violation.getColumn() == column</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RedundantImport.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.RedundantImport$RemoveRedundantImportsVisitor</mutatedClass>
+    <mutatedMethod>lambda$isAtViolationLocation$1</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/nio/file/Path::toAbsolutePath with receiver</description>
+    <lineContent>final Path absolutePath = violation.getFilePath().toAbsolutePath();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RedundantImport.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.RedundantImport$RemoveRedundantImportsVisitor</mutatedClass>
+    <mutatedMethod>lambda$visitCompilationUnit$0</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
+    <description>removed conditional - replaced equality check with false</description>
+    <lineContent>currentPackage) || !isAtViolationLocation(importStmt); })</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RedundantImport.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.RedundantImport$RemoveRedundantImportsVisitor</mutatedClass>
+    <mutatedMethod>visitCompilationUnit</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/nio/file/Path::toAbsolutePath with receiver</description>
+    <lineContent>this.sourcePath = cu.getSourcePath().toAbsolutePath();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SarifReportParser.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.SarifReportParser</mutatedClass>
+    <mutatedMethod>createViolation</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to de/jcup/sarif_2_1_0/model/Result$Level::name</description>
+    <lineContent>final String severity = result.getLevel().name();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SarifReportParser.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.SarifReportParser</mutatedClass>
+    <mutatedMethod>getFilePath</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>if (uri.startsWith(FILE_PREFIX)) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SarifReportParser.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.SarifReportParser</mutatedClass>
+    <mutatedMethod>getFilePath</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/nio/file/Path::of</description>
+    <lineContent>result = Path.of(uri);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SarifReportParser.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.SarifReportParser</mutatedClass>
+    <mutatedMethod>parse</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>if (run.getResults() != null) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SarifReportParser.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.SarifReportParser</mutatedClass>
+    <mutatedMethod>parse</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::valueOf</description>
+    <lineContent>throw new IllegalArgumentException(&quot;Failed to parse report: &quot; + reportPath, exception);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>UpperEll.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.UpperEll</mutatedClass>
+    <mutatedMethod>getDescription</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator</mutator>
+    <description>replaced return value with &quot;&quot; for org/checkstyle/autofix/recipe/UpperEll::getDescription</description>
+    <lineContent>return &quot;Replace lowercase &apos;l&apos; suffix in long literals with uppercase &apos;L&apos; &quot;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>UpperEll.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.UpperEll</mutatedClass>
+    <mutatedMethod>getDisplayName</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator</mutator>
+    <description>replaced return value with &quot;&quot; for org/checkstyle/autofix/recipe/UpperEll::getDisplayName</description>
+    <lineContent>return &quot;UpperEll recipe&quot;;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>UpperEll.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.UpperEll$UpperEllVisitor</mutatedClass>
+    <mutatedMethod>lambda$isAtViolationLocation$0</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>&amp;&amp; absolutePath.endsWith(sourcePath);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>UpperEll.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.UpperEll$UpperEllVisitor</mutatedClass>
+    <mutatedMethod>lambda$isAtViolationLocation$0</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/nio/file/Path::toAbsolutePath with receiver</description>
+    <lineContent>final Path absolutePath = violation.getFilePath().toAbsolutePath();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>UpperEll.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.UpperEll$UpperEllVisitor</mutatedClass>
+    <mutatedMethod>visitCompilationUnit</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/nio/file/Path::toAbsolutePath with receiver</description>
+    <lineContent>this.sourcePath = cu.getSourcePath().toAbsolutePath();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>UpperEll.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.UpperEll$UpperEllVisitor</mutatedClass>
+    <mutatedMethod>visitLiteral</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>&amp;&amp; result.getType() == JavaType.Primitive.Long</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>UpperEll.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.UpperEll$UpperEllVisitor</mutatedClass>
+    <mutatedMethod>visitLiteral</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to org/openrewrite/java/JavaIsoVisitor::visitLiteral with argument</description>
+    <lineContent>J.Literal result = super.visitLiteral(literal, executionContext);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>UpperEll.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.recipe.UpperEll$UpperEllVisitor</mutatedClass>
+    <mutatedMethod>visitLiteral</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>if (valueSource != null &amp;&amp; valueSource.endsWith(LOWERCASE_L)</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XmlReportParser.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.XmlReportParser</mutatedClass>
+    <mutatedMethod>parse</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Objects::requireNonNull</description>
+    <lineContent>Objects.requireNonNull(filename, &quot;File name can not be null&quot;);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XmlReportParser.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.XmlReportParser</mutatedClass>
+    <mutatedMethod>parse</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Objects::requireNonNull with argument</description>
+    <lineContent>Objects.requireNonNull(filename, &quot;File name can not be null&quot;);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XmlReportParser.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.XmlReportParser</mutatedClass>
+    <mutatedMethod>parse</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::valueOf</description>
+    <lineContent>throw new IllegalArgumentException(&quot;Failed to parse checkstyle XML report from: &quot;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XmlReportParser.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.XmlReportParser</mutatedClass>
+    <mutatedMethod>parseErrorTag</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Optional::empty</description>
+    <lineContent>Optional&lt;CheckstyleCheck&gt; source = Optional.empty();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XmlReportParser.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.XmlReportParser</mutatedClass>
+    <mutatedMethod>parseErrorTag</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>if (source.isPresent()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XmlReportParser.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.XmlReportParser</mutatedClass>
+    <mutatedMethod>parseFileTag</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>if (FILENAME_ATTR.equals(attribute.getName().getLocalPart())) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XmlReportParser.java</sourceFile>
+    <mutatedClass>org.checkstyle.autofix.parser.XmlReportParser</mutatedClass>
+    <mutatedMethod>parseFileTag</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
+    <description>removed conditional - replaced equality check with true</description>
+    <lineContent>while (attributes.hasNext()) {</lineContent>
+  </mutation>
+</suppressedMutations>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,10 @@
         <!-- Checkstyle properties -->
         <maven.checkstyle.plugin.version>3.6.0</maven.checkstyle.plugin.version>
         <checkstyle.version>12.1.0</checkstyle.version>
+
+        <!-- Pitest properties -->
+        <pitest.version>1.22.0</pitest.version>
+        <pitest.junit5.version>1.2.3</pitest.junit5.version>
     </properties>
 
     <dependencyManagement>
@@ -277,5 +281,72 @@
 
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>pitest</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.pitest</groupId>
+                        <artifactId>pitest-maven</artifactId>
+                        <version>${pitest.version}</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.pitest</groupId>
+                                <artifactId>pitest-junit5-plugin</artifactId>
+                                <version>${pitest.junit5.version}</version>
+                            </dependency>
+                        </dependencies>
+                        <configuration>
+                            <targetClasses>
+                                <param>org.checkstyle.*</param>
+                            </targetClasses>
+                            <targetTests>
+                                <param>org.checkstyle.*</param>
+                            </targetTests>
+
+                            <mutators>
+                                <mutator>INVERT_NEGS</mutator>
+                                <mutator>MATH</mutator>
+                                <mutator>NEGATE_CONDITIONALS</mutator>
+                                <mutator>NON_VOID_METHOD_CALLS</mutator>
+                                <mutator>REMOVE_CONDITIONALS_EQUAL_ELSE</mutator>
+                                <mutator>REMOVE_CONDITIONALS_EQUAL_IF</mutator>
+                                <mutator>REMOVE_CONDITIONALS_ORDER_ELSE</mutator>
+                                <mutator>REMOVE_CONDITIONALS_ORDER_IF</mutator>
+                                <mutator>VOID_METHOD_CALLS</mutator>
+                                <mutator>EXPERIMENTAL_ARGUMENT_PROPAGATION</mutator>
+                                <mutator>EXPERIMENTAL_BIG_DECIMAL</mutator>
+                                <mutator>EXPERIMENTAL_BIG_INTEGER</mutator>
+                                <mutator>EXPERIMENTAL_MEMBER_VARIABLE</mutator>
+                                <mutator>EXPERIMENTAL_NAKED_RECEIVER</mutator>
+                                <mutator>REMOVE_INCREMENTS</mutator>
+                                <mutator>EXPERIMENTAL_SWITCH</mutator>
+                                <mutator>REMOVE_SWITCH</mutator>
+                                <mutator>FALSE_RETURNS</mutator>
+                                <mutator>TRUE_RETURNS</mutator>
+                                <mutator>EMPTY_RETURNS</mutator>
+                                <mutator>NULL_RETURNS</mutator>
+                                <mutator>PRIMITIVE_RETURNS</mutator>
+                            </mutators>
+
+                            <outputFormats>
+                                <outputFormat>XML</outputFormat>
+                                <outputFormat>HTML</outputFormat>
+                            </outputFormats>
+
+                            <threads>4</threads>
+                            <timeoutFactor>10</timeoutFactor>
+                            <timeoutConstant>50000</timeoutConstant>
+
+                            <mutationThreshold>85</mutationThreshold>
+                            <coverageThreshold>90</coverageThreshold>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
Part of #106 

- enforce pitest
- suppress all existing mutations to cach all newly created
- mainly copy / pasted from the main checkstyle repo, simplified where possible