### PR TITLE
Issue #82: Implement recipe for AnnotationOnSameLine

### DIFF
--- a/src/main/java/org/checkstyle/autofix/CheckstyleCheck.java
+++ b/src/main/java/org/checkstyle/autofix/CheckstyleCheck.java
@@ -26,6 +26,9 @@ public enum CheckstyleCheck {
     NEWLINE_AT_END_OF_FILE("com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck"),
     UPPER_ELL("com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"),
     HEX_LITERAL_CASE("com.puppycrawl.tools.checkstyle.checks.HexLiteralCaseCheck"),
+    ANNOTATION_ON_SAME_LINE(
+        "com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationOnSameLineCheck"
+    ),
     REDUNDANT_IMPORT("com.puppycrawl.tools.checkstyle.checks.imports.RedundantImportCheck");
 
     private final String id;

--- a/src/main/java/org/checkstyle/autofix/CheckstyleRecipeRegistry.java
+++ b/src/main/java/org/checkstyle/autofix/CheckstyleRecipeRegistry.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 
 import org.checkstyle.autofix.parser.CheckConfiguration;
 import org.checkstyle.autofix.parser.CheckstyleViolation;
+import org.checkstyle.autofix.recipe.AnnotationOnSameLine;
 import org.checkstyle.autofix.recipe.FinalLocalVariable;
 import org.checkstyle.autofix.recipe.Header;
 import org.checkstyle.autofix.recipe.HexLiteralCase;
@@ -48,6 +49,7 @@ public final class CheckstyleRecipeRegistry {
         RECIPE_MAP.put(CheckstyleCheck.UPPER_ELL, UpperEll::new);
         RECIPE_MAP.put(CheckstyleCheck.HEX_LITERAL_CASE, HexLiteralCase::new);
         RECIPE_MAP.put(CheckstyleCheck.FINAL_LOCAL_VARIABLE, FinalLocalVariable::new);
+        RECIPE_MAP.put(CheckstyleCheck.ANNOTATION_ON_SAME_LINE, AnnotationOnSameLine::new);
         RECIPE_MAP_WITH_CONFIG.put(CheckstyleCheck.HEADER, Header::new);
         RECIPE_MAP_WITH_CONFIG.put(CheckstyleCheck.NEWLINE_AT_END_OF_FILE, NewlineAtEndOfFile::new);
         RECIPE_MAP.put(CheckstyleCheck.REDUNDANT_IMPORT, RedundantImport::new);

--- a/src/main/java/org/checkstyle/autofix/recipe/AnnotationOnSameLine.java
+++ b/src/main/java/org/checkstyle/autofix/recipe/AnnotationOnSameLine.java
@@ -1,0 +1,75 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle-openrewrite-recipes: Automatically fix Checkstyle violations with OpenRewrite.
+// Copyright (C) 2025 The Checkstyle OpenRewrite Recipes Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.autofix.recipe;
+
+import java.util.List;
+
+import org.checkstyle.autofix.parser.CheckstyleViolation;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+
+public class AnnotationOnSameLine extends Recipe {
+
+    private static final String NEW_LINE = "\n";
+    private static final String SPACE = " ";
+
+    /**
+     * Stored only to satisfy registry constructor contract.
+     */
+    private final List<CheckstyleViolation> violations;
+
+    public AnnotationOnSameLine(List<CheckstyleViolation> violations) {
+        this.violations = violations;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Annotation on same line";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Moves an annotation to the same line as its target.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+
+            @Override
+            public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                J.Annotation result = super.visitAnnotation(annotation, ctx);
+
+                if (result.getPrefix().getWhitespace().contains(NEW_LINE)) {
+                    final Space prefix = result.getPrefix();
+                    final String fixedWhitespace = prefix.getWhitespace()
+                            .replace(NEW_LINE, SPACE)
+                            .replaceAll("\\s+", SPACE);
+                    result = result.withPrefix(prefix.withWhitespace(fixedWhitespace));
+                }
+
+                return result;
+            }
+        };
+    }
+}
+


### PR DESCRIPTION
- Adds AnnotationOnSameLine.java recipe
- Declares enum constant in CheckstyleCheck.java
- Registers recipe in CheckstyleRecipeRegistry.java
- Only formatting changes, no semantic impact
- Coupling Issue Occuring:   ClassDataAbstractionCoupling: Class Data Abstraction Coupling is 8 (max allowed is 7) classes [AnnotationOnSameLine, EnumMap, FinalLocalVariable, Header, HexLiteralCase, NewlineAtEndOfFile, RedundantImport, UpperEll].
