### PR TITLE
Issue #269: Fixed the JUnit version mismatch and checkstyle Constructor Ordering violation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -118,13 +125,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/checkstyle/autofix/parser/CheckstyleViolation.java
+++ b/src/main/java/org/checkstyle/autofix/parser/CheckstyleViolation.java
@@ -35,6 +35,11 @@ public final class CheckstyleViolation {
 
     private final Path filePath;
 
+    public CheckstyleViolation(int line, String severity,
+                               CheckstyleCheck source, String message, Path filePath) {
+        this(line, -1, severity, source, message, filePath);
+    }
+
     public CheckstyleViolation(int line, int column, String severity,
                                CheckstyleCheck source, String message, Path filePath) {
         this.line = line;
@@ -43,11 +48,6 @@ public final class CheckstyleViolation {
         this.source = source;
         this.message = message;
         this.filePath = filePath;
-    }
-
-    public CheckstyleViolation(int line, String severity,
-                               CheckstyleCheck source, String message, Path filePath) {
-        this(line, -1, severity, source, message, filePath);
     }
 
     public Integer getLine() {


### PR DESCRIPTION
Issue #269 

In the PRs, created by dependabot, there is a version mismatch between junit-jupiter and junit-platform-engine.
For this PR, https://github.com/checkstyle/checkstyle-openrewrite-recipes/pull/257
This is caused by this dependency:
```
<dependency>
    <groupId>org.openrewrite</groupId>
    <artifactId>rewrite-test</artifactId>
    <scope>test</scope>
</dependency>
```
When maven built the project, it looked at rewrite-test first and noticed that it requires junit-platform-engine version 1.13.3

But as the Junit Jupiter version is upgraded to 6.1.0, it requires higher version, and this caused the issue

To fix this , i have added the Junit-bom which forces to use the latest version by dropping the one by rewrite-test

And for this PR, https://github.com/checkstyle/checkstyle-openrewrite-recipes/pull/255
rewrite-test pulled a newer version of Junit platform but pom includes Junit-jupiter version as 5.13.4, which looks for previous version of Junit Platform

For this, PR https://github.com/checkstyle/checkstyle-openrewrite-recipes/pull/258
It is failing because of ConstructorGrouping Check
```
Error:  src/main/java/org/checkstyle/autofix/parser/CheckstyleViolation.java:[48,5] (coding) ConstructorsDeclarationGrouping: Constructors should be ordered by increasing parameter count.
```