### PR TITLE
Issue #237: Removed some unit test from ViolationMarkerRecipeTest

### DIFF
--- a/src/main/java/org/checkstyle/autofix/marker/ViolationMarkerRecipe.java
+++ b/src/main/java/org/checkstyle/autofix/marker/ViolationMarkerRecipe.java
@@ -109,20 +109,13 @@ public class ViolationMarkerRecipe extends ScanningRecipe<Accumulator> {
         @Override
         public J.CompilationUnit visitCompilationUnit(J.CompilationUnit compUnit,
                                                       ExecutionContext executionContext) {
-            final J.CompilationUnit result;
-            if (compUnit.getMarkers().findFirst(MarkersApplied.class).isPresent()) {
-                result = compUnit;
-            }
-            else {
-                final Path sourcePath = compUnit.getSourcePath();
-                final List<CheckstyleViolation> fileViolations = violations.stream()
-                        .filter(violation -> violation.getFilePath().endsWith(sourcePath))
-                        .toList();
+            final Path sourcePath = compUnit.getSourcePath();
+            final List<CheckstyleViolation> fileViolations = violations.stream()
+                    .filter(violation -> violation.getFilePath().endsWith(sourcePath))
+                    .toList();
 
-                processFileViolations(compUnit, sourcePath, fileViolations);
-                result = compUnit;
-            }
-            return result;
+            processFileViolations(compUnit, sourcePath, fileViolations);
+            return compUnit;
         }
 
         private void processFileViolations(J.CompilationUnit compilationUnit, Path sourcePath,

--- a/src/test/java/org/checkstyle/autofix/marker/ViolationMarkerRecipeTest.java
+++ b/src/test/java/org/checkstyle/autofix/marker/ViolationMarkerRecipeTest.java
@@ -30,9 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.checkstyle.autofix.CheckFullName;
-import org.checkstyle.autofix.CheckstyleCheck;
-import org.checkstyle.autofix.parser.CheckstyleViolation;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Cursor;
@@ -66,34 +63,6 @@ public class ViolationMarkerRecipeTest {
 
         Assertions.assertEquals(expectedDescription, recipe.getDescription(),
                 "Invalid description");
-    }
-
-    @Test
-    public void testScannerIdempotencyClearsAccumulator() {
-        final Path path = Paths.get("TestScannerIdemClear.java");
-        final CheckstyleViolation violation = new CheckstyleViolation(
-                1, 1, "error", new CheckstyleCheck(
-                        CheckFullName.FINAL_CLASS, "id"),
-                "msg", path);
-
-        final ViolationMarkerRecipe recipe = new ViolationMarkerRecipe(List.of(violation));
-        final JavaParser parser = JavaParser.fromJavaVersion().build();
-        final J.CompilationUnit compUnit = parser.parse(
-                "final class A {}").findFirst().get().withSourcePath(path);
-
-        final ExecutionContext ctx = new InMemoryExecutionContext();
-        final var acc = recipe.getInitialValue(ctx);
-
-        recipe.getScanner(acc).visit(compUnit, ctx);
-        Assertions.assertFalse(acc.getByFile(path).isEmpty(), "First scan should find violations");
-
-        final J.CompilationUnit afterVisit = (J.CompilationUnit)
-                recipe.getVisitor(acc).visit(compUnit, ctx);
-        acc.putByFile(path, Collections.emptyMap());
-        recipe.getScanner(acc).visit(afterVisit, ctx);
-
-        Assertions.assertTrue(acc.getByFile(path).isEmpty(),
-                "Scanner should completely skip the file, leaving accumulator empty");
     }
 
     @Test


### PR DESCRIPTION
Issue #237 

I have removed the redundant if (compUnit.getMarkers().findFirst(MarkersApplied.class).isPresent()) check from ScannerVisitor.visitCompilationUnit() in ViolationMarkerRecipe.java

In the OpenRewrite ScanningRecipe lifecycle, the MarkerVisitor already properly checks for the presence of the MarkersApplied marker before applying any changes to the AST

Because MarkerVisitor already guards against re-evaluating nodes where the markers have been applied, the check inside ScannerVisitor was a redundant optimization